### PR TITLE
added launch setting to allow for vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Lotus Debug",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "runserver"
+            ],
+            "console":"internalConsole",
+            "django": true,
+            "justMyCode": false
+        }
+    ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
   db:
     image: postgres:14-alpine
     restart: on-failure
+    env_file:
+      - ./env/.env
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
       - POSTGRES_USER=${POSTGRES_USER:-db_user}


### PR DESCRIPTION
simple addition to launch.json files to allow us to set breakpoints when running al ocal version of lotus for dev. Better than our current method of print debugging (lol)