### PR TITLE
Resolve "zustand implementation"

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5433:5432
+      - 5432:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:

--- a/frontend/src/components/Settings/settings/tabs/GeneralTab.tsx
+++ b/frontend/src/components/Settings/settings/tabs/GeneralTab.tsx
@@ -23,6 +23,10 @@ import { PricingUnit } from "../../../../types/pricing-unit-type";
 import { toast } from "react-toastify";
 import LoadingSpinner from "../../../LoadingSpinner";
 import PricingUnitDropDown from "../../../PricingUnitDropDown";
+import useGlobalStore, {
+  IOrgStoreType,
+} from "../../../../stores/useGlobalstore";
+import { QueryErrors } from "../../../../types/error-response-types";
 
 interface InviteWithEmailForm extends HTMLFormControlsCollection {
   email: string;
@@ -38,6 +42,8 @@ const GeneralTab: FC = () => {
   const [isEdit, setIsEdit] = useState(false);
   const [form] = Form.useForm();
   const queryClient = useQueryClient();
+  const org = useGlobalStore((state) => state.org);
+  const setOrgInfoToStore = useGlobalStore((state) => state.setOrgInfo);
   const [currentCurrency, setCurrentCurrency] = useState("");
 
   const {
@@ -51,17 +57,39 @@ const GeneralTab: FC = () => {
       })
   );
 
-  const { data, isLoading, isError } = useQuery(["organization"], () =>
-    Organization.get().then((res) => {
-      //if the default currency is null, then don't set it, otherwise setCurrentCurrency
-      if (
-        res[0].default_currency !== undefined &&
-        res[0].default_currency !== null
-      ) {
-        setCurrentCurrency(res[0].default_currency.code);
-      }
-      return res[0];
-    })
+  const { isLoading } = useQuery(
+    ["organization"],
+    () =>
+      Organization.get().then((res) => {
+        //if the default currency is null, then don't set it, otherwise setCurrentCurrency
+        if (
+          res[0].default_currency !== undefined &&
+          res[0].default_currency !== null
+        ) {
+          setCurrentCurrency(res[0].default_currency.code);
+        }
+        return res[0];
+      }),
+    {
+      onSuccess: (data) => {
+        if (
+          data.default_currency !== undefined &&
+          data.default_currency !== null
+        ) {
+          setCurrentCurrency(data.default_currency.code);
+        }
+        const storeOrgObject: IOrgStoreType = {
+          organization_id: data.organization_id,
+          company_name: data.company_name,
+          default_currency: data.default_currency
+            ? data.default_currency
+            : undefined,
+          environment: undefined,
+        };
+
+        setOrgInfoToStore(storeOrgObject);
+      },
+    }
   );
 
   const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -74,7 +102,7 @@ const GeneralTab: FC = () => {
       onSuccess: (response) => {
         toast.success("Invite sent");
       },
-      onError: (error: any) => {
+      onError: (error: QueryErrors) => {
         if (error.response.data) {
           toast.error(
             Array.isArray(error.response.data.email)
@@ -116,40 +144,49 @@ const GeneralTab: FC = () => {
 
       <Divider />
 
-      <div className="flex flex-col w-6/12 justify-between">
-        {mutation.isLoading && <LoadingSpinner />}
-        <p className=" text-[16px]">
-          <b>Company Name:</b> {data?.company_name ? data.company_name : "N/A"}
-        </p>
-        <p className=" text-[16px]">
-          <b className="">Default Organization Currency:</b>{" "}
-          {data?.default_currency !== undefined &&
-          data?.default_currency !== null ? (
-            <Tag>
-              {data.default_currency?.name +
-                " " +
-                data?.default_currency?.symbol}
-            </Tag>
-          ) : (
-            "N/A"
-          )}
-        </p>
-
-        <div className="">
-          <Button onClick={() => setIsEdit(true)} className="justify-self-end">
-            Edit
-          </Button>
+      {isLoading ? (
+        <div className="mt-10">
+          <LoadingSpinner />
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col w-6/12 justify-between">
+          {mutation.isLoading && <LoadingSpinner />}
+          <p className=" text-[16px]">
+            <b>Company Name:</b> {org.company_name}
+          </p>
+          <p className=" text-[16px]">
+            <b className="">Default Organization Currency:</b>{" "}
+            {org.default_currency !== undefined &&
+            org.default_currency !== null ? (
+              <Tag>
+                {org.default_currency?.name +
+                  " " +
+                  org.default_currency?.symbol}
+              </Tag>
+            ) : (
+              "N/A"
+            )}
+          </p>
+
+          <div className="">
+            <Button
+              onClick={() => setIsEdit(true)}
+              className="justify-self-end"
+            >
+              Edit
+            </Button>
+          </div>
+        </div>
+      )}
       <Modal
         title="Edit Organization Settings"
         visible={isEdit}
         onCancel={() => setIsEdit(false)}
         okText="Save"
         onOk={() => {
-          if (data) {
+          if (org.organization_id.length) {
             updateOrg.mutate({
-              org_id: data.organization_id,
+              org_id: org.organization_id,
               default_currency_code: currentCurrency,
             });
             form.resetFields();
@@ -161,8 +198,8 @@ const GeneralTab: FC = () => {
           <Form
             form={form}
             initialValues={{
-              company_name: data?.company_name,
-              default_currency: data?.default_currency?.code,
+              company_name: org?.company_name,
+              default_currency: org?.default_currency?.code,
             }}
           >
             <Form.Item

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,6 +9,8 @@ import LoadingSpinner from "../components/LoadingSpinner";
 import { instance } from "../api/api";
 import Cookies from "universal-cookie";
 import posthog from "posthog-js";
+import { QueryErrors } from "../types/error-response-types";
+import useGlobalStore from "../stores/useGlobalstore";
 
 const cookies = new Cookies();
 
@@ -25,6 +27,7 @@ const Login: FC = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const us = useGlobalStore((state) => state.username);
   const queryClient = useQueryClient();
 
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -49,6 +52,7 @@ const Login: FC = () => {
       onSuccess: (response) => {
         setIsAuthenticated(true);
         const { token, detail, user } = response;
+        console.log(user);
         if (import.meta.env.VITE_API_URL === "https://api.uselotus.io/") {
           posthog.group("company", user.organization_id, {
             company_name: user.company_name,
@@ -65,7 +69,7 @@ const Login: FC = () => {
         queryClient.refetchQueries("session");
         redirectDashboard();
       },
-      onError: (error) => {
+      onError: (error: QueryErrors) => {
         // setError(error.message);
         if (error.response.status === 403) {
           toast.error("Please login again.");

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -27,7 +27,7 @@ const Login: FC = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const us = useGlobalStore((state) => state.username);
+  const setUsernameToStore = useGlobalStore((state) => state.setUsername);
   const queryClient = useQueryClient();
 
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -52,7 +52,7 @@ const Login: FC = () => {
       onSuccess: (response) => {
         setIsAuthenticated(true);
         const { token, detail, user } = response;
-        console.log(user);
+        setUsernameToStore(user.username);
         if (import.meta.env.VITE_API_URL === "https://api.uselotus.io/") {
           posthog.group("company", user.organization_id, {
             company_name: user.company_name,

--- a/frontend/src/stores/useGlobalstore.ts
+++ b/frontend/src/stores/useGlobalstore.ts
@@ -1,24 +1,30 @@
 import create from "zustand";
+import { OrganizationType } from "../types/account-type";
+import { PricingUnit } from "../types/pricing-unit-type";
 type GlobalStoreState = {
   username: string;
-  org: IOrg;
+  org: IOrgStoreType;
   setUsername: (username: string) => void;
-  setOrgInfo: (org: IOrg) => void;
+  setOrgInfo: (org: IOrgStoreType) => void;
 };
-interface IOrg {
+
+interface IOrgStoreType {
+  organization_id: string;
   company_name: string;
-  currency: string;
+  default_currency?: PricingUnit;
   environment?: string;
 }
 
 const useGlobalStore = create<GlobalStoreState>((set) => ({
   username: "",
   org: {
-    company_name: "",
-    currency: "",
+    organization_id: "",
+    company_name: "N/A",
+    default_currency: undefined,
     environment: undefined,
   },
   setUsername: (username: string) => set({ username }),
-  setOrgInfo: (org: IOrg) => set({ org }),
+  setOrgInfo: (org: IOrgStoreType) => set({ org }),
 }));
 export default useGlobalStore;
+export { IOrgStoreType };

--- a/frontend/src/stores/useGlobalstore.ts
+++ b/frontend/src/stores/useGlobalstore.ts
@@ -1,0 +1,22 @@
+import create from "zustand";
+type GlobalStoreState = {
+  username: string;
+  org: IOrg;
+};
+interface IOrg {
+  company_name: string;
+  currency: string;
+  environment?: string;
+}
+
+const useGlobalStore = create<GlobalStoreState>((set) => ({
+  username: "",
+  org: {
+    company_name: "",
+    currency: "",
+    environment: undefined,
+  },
+  setUsername: (username: string) => set({ username }),
+  setOrgInfo: (org: IOrg) => set({ org }),
+}));
+export default useGlobalStore;

--- a/frontend/src/stores/useGlobalstore.ts
+++ b/frontend/src/stores/useGlobalstore.ts
@@ -2,6 +2,8 @@ import create from "zustand";
 type GlobalStoreState = {
   username: string;
   org: IOrg;
+  setUsername: (username: string) => void;
+  setOrgInfo: (org: IOrg) => void;
 };
 interface IOrg {
   company_name: string;


### PR DESCRIPTION
## Closes 
Closes LOT-419

## Description 
This PR creates a global Zustand store with org and user data. This store is used on our settings page. 
It uses Zustand in place of the data object from Tanstack Query. It also improves the UX by using the isLoading so there's no flicker like there was before. 

## Testing 
- [ ] Log onto the app.
- [ ] Go to the settings page. 
- [ ] It should render global info.
- [ ] Editing the currency should still work.
- [ ] It should not flicker "N/A" then data.