### PR TITLE
Resolve "When cancelling subscription from frontend, query doesn't invalidate and refresh"

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:
@@ -85,7 +85,7 @@ services:
     env_file:
       - ./env/.env.dev
     ports:
-      - 3000:3000
+      - 3001:3000
     command: yarn run dev --host 0.0.0.0 --port 3000
     volumes:
       - ./frontend/src:/frontend/src:delegated

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5433:5432
+      - 5432:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:
@@ -85,7 +85,7 @@ services:
     env_file:
       - ./env/.env.dev
     ports:
-      - 3001:3000
+      - 3000:3000
     command: yarn run dev --host 0.0.0.0 --port 3000
     volumes:
       - ./frontend/src:/frontend/src:delegated

--- a/frontend/src/components/Customers/CustomerDetail.tsx
+++ b/frontend/src/components/Customers/CustomerDetail.tsx
@@ -101,7 +101,7 @@ function CustomerDetail(props: {
           "balance_adjustments",
           props.customer_id,
         ]);
-        refetch({ queryKey: ["customer_detail", props.customer_id] });
+        refetch();
         toast.success("Subscription cancelled successfully");
       },
     }

--- a/frontend/src/components/Customers/CustomerDetail.tsx
+++ b/frontend/src/components/Customers/CustomerDetail.tsx
@@ -47,7 +47,7 @@ function CustomerDetail(props: {
     DetailPlan[]
   >([]);
 
-  const { data, isLoading }: UseQueryResult<CustomerType> =
+  const { data, isLoading, refetch }: UseQueryResult<CustomerType> =
     useQuery<CustomerType>(
       ["customer_detail", props.customer_id],
       () =>
@@ -58,7 +58,7 @@ function CustomerDetail(props: {
         enabled: props.visible,
       }
     );
-
+  console.log(data);
   const { data: cost_analysis, isLoading: cost_analysis_loading } =
     useQuery<CustomerCostType>(
       ["customer_cost_analysis", props.customer_id, startDate, endDate],
@@ -83,7 +83,7 @@ function CustomerDetail(props: {
           "balance_adjustments",
           props.customer_id,
         ]);
-        queryClient.invalidateQueries(["customer_detail", props.customer_id]);
+        refetch();
         toast.success("Subscription created successfully");
       },
     }
@@ -101,7 +101,7 @@ function CustomerDetail(props: {
           "balance_adjustments",
           props.customer_id,
         ]);
-        queryClient.invalidateQueries(["customer_detail", props.customer_id]);
+        refetch({ queryKey: ["customer_detail", props.customer_id] });
         toast.success("Subscription cancelled successfully");
       },
     }
@@ -117,7 +117,7 @@ function CustomerDetail(props: {
           "balance_adjustments",
           props.customer_id,
         ]);
-        queryClient.invalidateQueries(["customer_detail", props.customer_id]);
+        refetch();
         toast.success("Subscription switched successfully");
       },
     }
@@ -129,7 +129,7 @@ function CustomerDetail(props: {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["customer_list"]);
-        queryClient.invalidateQueries(["customer_detail", props.customer_id]);
+        refetch();
         toast.success("Subscription auto renew turned off");
       },
     }
@@ -200,7 +200,7 @@ function CustomerDetail(props: {
             <div className="flex flex-row items-center">
               <div className="plansDetailLabel">ID:&nbsp; </div>
               <div className="plansDetailValue font-menlo">
-                  <CopyText showIcon textToCopy={data?.customer_id}/>
+                <CopyText showIcon textToCopy={data ? data.customer_id : ""} />
               </div>
             </div>
           </div>

--- a/frontend/src/components/Customers/CustomerSubscriptionView.tsx
+++ b/frontend/src/components/Customers/CustomerSubscriptionView.tsx
@@ -82,16 +82,6 @@ const SubscriptionView: FC<Props> = ({
   const [planList, setPlanList] =
     useState<{ label: string; value: string }[]>();
 
-  const [subscriptionPlans, setSubscriptionPlans] = useState<
-    SubscriptionType[]
-  >(subscriptions || []);
-
-  useEffect(() => {
-    if (subscriptions.length > 0) {
-      setSubscriptionPlans(subscriptions);
-    }
-  }, [subscriptions]);
-
   const selectPlan = (plan_id: string) => {
     setSelectedPlan(plan_id);
   };
@@ -219,7 +209,7 @@ const SubscriptionView: FC<Props> = ({
         subscription_filters: subscription_filters,
       },
       {
-        replace_plan_id: selectedOptions[0].value,
+        replace_plan_id: selectedOptions[0].value as string,
       }
     );
   };
@@ -253,7 +243,7 @@ const SubscriptionView: FC<Props> = ({
     }
     form.resetFields();
   };
-  if (subscriptionPlans.length === 0) {
+  if (subscriptions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center">
         <h2 className="mb-2 pb-4 pt-4 font-bold text-main">No Subscription</h2>
@@ -291,7 +281,7 @@ const SubscriptionView: FC<Props> = ({
       <h2 className="mb-2 pb-4 pt-4 font-bold text-main">Active Plans</h2>
       <div className="flex flex-col justify-center">
         <List>
-          {subscriptionPlans.map((subPlan) => (
+          {subscriptions.map((subPlan) => (
             <Fragment key={subPlan.billing_plan.plan_id}>
               <List.Item>
                 <Card className=" bg-grey3 w-full">


### PR DESCRIPTION
## Closes 
LOT-428

## Description 
We had a bug where cancelling a subscription would not invalidate the query and refetch. 

It was two fold:
- Primarily , we were setting props to state and not syncing properly. We really shouldn't ever be doing that. See [you might not need an effect](When cancelling subscription from frontend, query doesn't invalidate and refresh). 
- We were making a lazy query which means we needed to call `refetch` manually. 

## Testing 
- [ ] Log onto the app. 
- [ ] Go to customers. 
- [ ] Select a customer with a subscription (or create one). 
- [ ] Cancel a subscription. 
- [ ] It should immediately re-route to the subscription creation view. 
- [ ] Everything else should work as expected.
