### PR TITLE
Resolve "Creating & deleting external plans – Optimistic UI."

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:
@@ -85,7 +85,7 @@ services:
     env_file:
       - ./env/.env.dev
     ports:
-      - 3000:3000
+      - 3001:3000
     command: yarn run dev --host 0.0.0.0 --port 3000
     volumes:
       - ./frontend/src:/frontend/src:delegated

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -3,7 +3,7 @@ services:
     image: timescale/timescaledb-ha:pg14-latest
     restart: on-failure
     ports:
-      - 5433:5432
+      - 5432:5432
     volumes:
       - ./pgdata_dev:/var/lib/postgresql/data
     env_file:
@@ -85,7 +85,7 @@ services:
     env_file:
       - ./env/.env.dev
     ports:
-      - 3001:3000
+      - 3000:3000
     command: yarn run dev --host 0.0.0.0 --port 3000
     volumes:
       - ./frontend/src:/frontend/src:delegated

--- a/frontend/src/components/Plans/LinkExternalIds.tsx
+++ b/frontend/src/components/Plans/LinkExternalIds.tsx
@@ -13,7 +13,6 @@ interface LinkExternalIdsProps {
 
 const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
   externalIds: tags,
-  setExternalLinks,
   createExternalLink,
   deleteExternalLink,
 }) => {
@@ -21,7 +20,7 @@ const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<InputRef>(null);
   const editInputRef = useRef<InputRef>(null);
-  console.log(tags);
+
   useEffect(() => {
     if (inputVisible) {
       inputRef.current?.focus();

--- a/frontend/src/components/Plans/LinkExternalIds.tsx
+++ b/frontend/src/components/Plans/LinkExternalIds.tsx
@@ -2,7 +2,7 @@ import { PlusOutlined } from "@ant-design/icons";
 import type { InputRef } from "antd";
 import { Input, Tag, Tooltip } from "antd";
 // @ts-ignore
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, memo } from "react";
 
 interface LinkExternalIdsProps {
   externalIds: string[];
@@ -11,18 +11,17 @@ interface LinkExternalIdsProps {
   deleteExternalLink?: (link) => void;
 }
 
-const LinkExternalIds: React.FC<LinkExternalIdsProps> = ({
-  externalIds,
+const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
+  externalIds: tags,
   setExternalLinks,
   createExternalLink,
   deleteExternalLink,
 }) => {
-  const [tags, setTags] = useState<string[]>(externalIds);
   const [inputVisible, setInputVisible] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<InputRef>(null);
   const editInputRef = useRef<InputRef>(null);
-
+  console.log(tags);
   useEffect(() => {
     if (inputVisible) {
       inputRef.current?.focus();
@@ -34,9 +33,6 @@ const LinkExternalIds: React.FC<LinkExternalIdsProps> = ({
   }, [inputValue]);
 
   const handleClose = (removedTag: string) => {
-    const newTags = tags.filter((tag) => tag !== removedTag);
-    setTags(newTags);
-    setExternalLinks && setExternalLinks(newTags);
     deleteExternalLink && deleteExternalLink(removedTag);
   };
 
@@ -46,9 +42,6 @@ const LinkExternalIds: React.FC<LinkExternalIdsProps> = ({
 
   const handleInputConfirm = () => {
     if (inputValue && tags.indexOf(inputValue) === -1) {
-      const links = [...tags, inputValue];
-      setTags(links);
-      setExternalLinks && setExternalLinks(links);
       createExternalLink && createExternalLink(inputValue);
     }
     setInputVisible(false);
@@ -97,5 +90,5 @@ const LinkExternalIds: React.FC<LinkExternalIdsProps> = ({
     </>
   );
 };
-
+const LinkExternalIds = memo(LinksExternalIds);
 export default LinkExternalIds;

--- a/frontend/src/components/Plans/PlanDetails/PlanDetails.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanDetails.tsx
@@ -46,6 +46,9 @@ const PlanDetails: FC = () => {
           position: toast.POSITION.TOP_CENTER,
         });
       },
+      onSettled: () => {
+        queryClient.invalidateQueries(["plan_detail", planId]);
+      },
     }
   );
 
@@ -58,10 +61,18 @@ const PlanDetails: FC = () => {
           position: toast.POSITION.TOP_CENTER,
         });
       },
-      onError: () => {
+      onError: (_, __, context) => {
+        // roll back since it failed
+        queryClient.setQueryData(
+          ["plan_detail", planId],
+          context?.previousPlan
+        );
         toast.error("Failed to delete Plan external links", {
           position: toast.POSITION.TOP_CENTER,
         });
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries(["plan_detail", planId]);
       },
     }
   );
@@ -122,7 +133,7 @@ const PlanDetails: FC = () => {
       }),
     { refetchOnMount: "always" }
   );
-  console.log(plan);
+
   const navigateCreateCustomPlan = () => {
     navigate("/create-custom/" + planId);
   };

--- a/frontend/src/types/customer-type.ts
+++ b/frontend/src/types/customer-type.ts
@@ -6,6 +6,7 @@ import { PricingUnit } from "./pricing-unit-type";
 export interface CustomerType {
   customer_id: string;
   email: string;
+  name: string;
   customer_name: string;
   invoices: InvoiceType[];
   total_amount_due: number;


### PR DESCRIPTION
## Closes 
LOT-429

## Description 
This implements optimistic UI for creating and deleting external IDs. It uses React Query's mechanism. It also cleans up some type errors, unused props and fixes uses props as state. 

## Testing 
- [ ] Log onto the app. 
- [ ] Go to plans.
- [ ] Select a plan. 
- [ ] It should render the external IDs (if previously created as normal). 
- [ ] Add an external ID, it should immediately update. 
- [ ] Delete an external ID, it should immediately update. 
- [ ] Cause the network request to fail (switching off Wi-Fi for instance). and try again, it should update then revert. 
