### PR TITLE
Fix UI nits & tiny bugs

### DIFF
--- a/backend/metering_billing/demos.py
+++ b/backend/metering_billing/demos.py
@@ -1156,7 +1156,6 @@ def setup_demo4(
                     sr.billing_plan.replace_with = cur_replace_with
                     sr.save()
                 end_time = time.time()
-                print("Time to generate 1 month data: ", end_time - start_time)
     now = now_utc()
     # backtest = Backtest.objects.create(
     #     backtest_name=organization,

--- a/backend/metering_billing/tests/test_organization.py
+++ b/backend/metering_billing/tests/test_organization.py
@@ -79,7 +79,6 @@ class TestOrganizationTags:
             payload,
             format="json",
         )
-        print(response.data)
         assert response.status_code == status.HTTP_200_OK
         assert sorted(
             list(

--- a/backend/metering_billing/tests/test_register.py
+++ b/backend/metering_billing/tests/test_register.py
@@ -82,7 +82,6 @@ class TestRegister:
             data=json.dumps(payload, cls=DjangoJSONEncoder),
             content_type="application/json",
         )
-        print(response.data)
 
         users_after = User.objects.all().count()
         organizations_after = Organization.objects.all().count()

--- a/frontend/src/components/Dashboard/MetricBarGraph.tsx
+++ b/frontend/src/components/Dashboard/MetricBarGraph.tsx
@@ -32,13 +32,36 @@ function MetricBarGraph(props: { range: any }) {
         return res;
       })
     );
+  const changeMetric = (value: string) => {
+    let compressedArray: ChartDataType[] = [];
+    setSelectedMetric(value);
 
+    if (data?.metrics && Object.keys(data.metrics).length > 0) {
+      const daily_data = data?.metrics[value].data;
+
+      for (let i = 0; i < daily_data.length; i++) {
+        const date = daily_data[i].date;
+        for (const k in daily_data[i].customer_usages) {
+          compressedArray.push({
+            date: date,
+            metric_amount: daily_data[i].customer_usages[k],
+            type: k,
+          });
+        }
+      }
+    }
+    setChartData(compressedArray);
+  };
   useEffect(() => {
     console.log("data", data);
     if (data?.metrics && Object.keys(data.metrics).length > 0) {
       setMetricList(Object.keys(data.metrics));
       setSelectedMetric(Object.keys(data.metrics)[0]);
       changeMetric(Object.keys(data.metrics)[0]);
+    } else {
+      setMetricList([]);
+      setSelectedMetric(undefined);
+      changeMetric("");
     }
   }, [data]);
 
@@ -74,25 +97,6 @@ function MetricBarGraph(props: { range: any }) {
       </div>
     );
   }
-
-  const changeMetric = (value: string) => {
-    let compressedArray: ChartDataType[] = [];
-    setSelectedMetric(value);
-
-    const daily_data = data.metrics[value].data;
-
-    for (let i = 0; i < daily_data.length; i++) {
-      const date = daily_data[i].date;
-      for (const k in daily_data[i].customer_usages) {
-        compressedArray.push({
-          date: date,
-          metric_amount: daily_data[i].customer_usages[k],
-          type: k,
-        });
-      }
-    }
-    setChartData(compressedArray);
-  };
 
   return (
     <Paper border={true} color="white">

--- a/frontend/src/components/Dashboard/MetricBarGraph.tsx
+++ b/frontend/src/components/Dashboard/MetricBarGraph.tsx
@@ -32,7 +32,7 @@ function MetricBarGraph(props: { range: any }) {
         return res;
       })
     );
-
+  
   useEffect(() => {
     if (data?.metrics && Object.keys(data.metrics).length > 0) {
       setMetricList(Object.keys(data.metrics));

--- a/frontend/src/components/Dashboard/MetricBarGraph.tsx
+++ b/frontend/src/components/Dashboard/MetricBarGraph.tsx
@@ -53,7 +53,6 @@ function MetricBarGraph(props: { range: any }) {
     setChartData(compressedArray);
   };
   useEffect(() => {
-    console.log("data", data);
     if (data?.metrics && Object.keys(data.metrics).length > 0) {
       setMetricList(Object.keys(data.metrics));
       setSelectedMetric(Object.keys(data.metrics)[0]);

--- a/frontend/src/components/Dashboard/MetricBarGraph.tsx
+++ b/frontend/src/components/Dashboard/MetricBarGraph.tsx
@@ -32,8 +32,9 @@ function MetricBarGraph(props: { range: any }) {
         return res;
       })
     );
-  
+
   useEffect(() => {
+    console.log("data", data);
     if (data?.metrics && Object.keys(data.metrics).length > 0) {
       setMetricList(Object.keys(data.metrics));
       setSelectedMetric(Object.keys(data.metrics)[0]);

--- a/frontend/src/components/Dashboard/RevenueDisplay.tsx
+++ b/frontend/src/components/Dashboard/RevenueDisplay.tsx
@@ -27,11 +27,12 @@ function RevenueDisplay(props: {
   isLoading: boolean;
 }) {
   const [percentageChange, setPercentageChange] = useState<number>(0);
+
   useEffect(() => {
     setPercentageChange(
       computePercentageChange(props.earned_revenue_1, props.earned_revenue_2)
     );
-  }, [props.total_revenue_1, props.total_revenue_2]);
+  }, [props.earned_revenue_1, props.earned_revenue_2]);
   return (
     <Paper color="white" border={true}>
       <div className="grid grid-flow-col auto-cols-auto	 justify-between">

--- a/frontend/src/components/Metrics/MetricDetails.tsx
+++ b/frontend/src/components/Metrics/MetricDetails.tsx
@@ -33,7 +33,6 @@ const MetricDetails: FC<MetricDetailsProps> = ({ metric, onclose }) => {
       },
 
       onError: (error: any) => {
-        console.log(error);
         toast.error(error.response.data.detail);
       },
     }

--- a/frontend/src/components/Plans/LinkExternalIds.tsx
+++ b/frontend/src/components/Plans/LinkExternalIds.tsx
@@ -16,6 +16,7 @@ const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
   externalIds: tags,
   createExternalLink,
   deleteExternalLink,
+  setExternalLinks,
 }) => {
   const [inputVisible, setInputVisible] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -41,8 +42,15 @@ const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
   };
 
   const handleInputConfirm = () => {
-    if (inputValue && tags.indexOf(inputValue) === -1) {
+    if (inputValue && tags.indexOf(inputValue) === -1 && !setExternalLinks) {
       createExternalLink && createExternalLink(inputValue);
+    } else if (
+      inputValue &&
+      tags.indexOf(inputValue) === -1 &&
+      setExternalLinks
+    ) {
+      tags.push(inputValue);
+      setExternalLinks(tags);
     }
     setInputVisible(false);
     setInputValue("");
@@ -85,7 +93,11 @@ const LinksExternalIds: React.FC<LinkExternalIdsProps> = ({
       {!inputVisible && (
         <Badge
           onClick={() => setInputVisible(true)}
-          className="bg-[#E0E7FF] text-[#3730A3]"
+          className={
+            setExternalLinks
+              ? "bg-[#E0E7FF] text-[#3730A3] cursor-pointer w-1/2"
+              : "bg-[#E0E7FF] text-[#3730A3] cursor-pointer"
+          }
         >
           <Badge.Content>Link External IDs</Badge.Content>
         </Badge>

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -1,5 +1,5 @@
 // @ts-ignore
-import React, { FC, useRef, useState } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 import "./PlanDetails.css";
 import { Table, Typography, Tag, Modal, Button, InputNumber } from "antd";
 import { CheckCircleOutlined } from "@ant-design/icons";
@@ -33,6 +33,7 @@ import { toast } from "react-toastify";
 interface PlanComponentsProps {
   components?: Component[];
   plan: PlanType;
+  refetch: VoidFunction;
   updateBillingFrequencyMutation: (
     billing_frequency: "monthly" | "quarterly" | "yearly"
   ) => void;
@@ -331,6 +332,7 @@ export const PlanInfo = ({ version, plan }: PlanInfoProps) => {
 const PlanComponents: FC<PlanComponentsProps> = ({
   components,
   plan,
+  refetch,
   updateBillingFrequencyMutation,
   alerts,
   plan_version_id,
@@ -343,16 +345,16 @@ const PlanComponents: FC<PlanComponentsProps> = ({
   const [currentAlertId, setCurrentAlertId] = useState<string>();
 
   const queryClient = new QueryClient();
-
   const createAlertMutation = useMutation(
     (post: CreateAlertType) => Plan.createAlert(post),
     {
       onSuccess: () => {
         setIsModalVisible(false);
-        queryClient.invalidateQueries("plan_details");
+
         setAlertThreshold(0);
+        refetch();
         toast.success("Successfully created alert. Please the refresh page.");
-        window.location.reload(false);
+        // window.location.reload(false);
       },
     }
   );
@@ -362,13 +364,13 @@ const PlanComponents: FC<PlanComponentsProps> = ({
     {
       onSuccess: () => {
         setIsModalVisible(false);
-        queryClient.invalidateQueries("plan_details");
-        toast.success("Deleted alert");
-        window.location.reload(false);
+
+        refetch();
+        // toast.success("Deleted alert");
       },
     }
   );
-
+  useEffect(() => {}, [plan]);
   const deleteAlert = (usage_alert_id: string) => {
     deleteAlertMutation.mutate({
       usage_alert_id: usage_alert_id,
@@ -563,9 +565,10 @@ const PlanComponents: FC<PlanComponentsProps> = ({
               <div className="flex flex-row justify-center items-center gap-4">
                 {currentComponent?.billable_metric.metric_name} reaches:{"  "}
                 <InputNumber
-                  className="ml-2 mr-2"
+                  type={"number"}
+                  pattern="[0-9]+"
                   onChange={(value) => {
-                    console.log(typeof value);
+                    console.log(value);
                     if (value && typeof value === "number") {
                       setAlertThreshold(value);
                     }

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -353,7 +353,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
 
         setAlertThreshold(0);
         refetch();
-        toast.success("Successfully created alert. Please the refresh page.");
+        toast.success("Successfully created alert.");
         // window.location.reload(false);
       },
     }

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -580,7 +580,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                   value={alertThreshold}
                 />
                 {isInvalid && (
-                  <div className="bg-red-800">Please enter a number</div>
+                  <div className="text-red-800">Please enter a number</div>
                 )}
               </div>
             </Modal>

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -563,7 +563,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                     ]
               }
             >
-              <div className="flex flex-row justify-center items-center gap-4">
+              <div className="flex flex-col justify-center items-center gap-4">
                 {currentComponent?.billable_metric.metric_name} reaches:{"  "}
                 <InputNumber
                   type={"number"}

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -343,7 +343,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
   const [isCreateAlert, setIsCreateAlert] = useState(true);
   const [currentComponent, setCurrentComponent] = useState<Component>();
   const [currentAlertId, setCurrentAlertId] = useState<string>();
-
+  const [isInvalid, setIsInvalid] = useState(false);
   const queryClient = new QueryClient();
   const createAlertMutation = useMutation(
     (post: CreateAlertType) => Plan.createAlert(post),
@@ -553,6 +553,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                       <Button
                         key="submit"
                         type="primary"
+                        disabled={isInvalid}
                         onClick={() =>
                           submitAlertModal(currentComponent, currentAlertId)
                         }
@@ -568,16 +569,19 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                   type={"number"}
                   pattern="[0-9]+"
                   onChange={(value) => {
-                    console.log(value);
                     if (value && typeof value === "number") {
                       setAlertThreshold(value);
+                      setIsInvalid(false);
                     }
                     if (value === null) {
-                      toast.success("Please enter a number");
+                      setIsInvalid(true);
                     }
                   }}
                   value={alertThreshold}
                 />
+                {isInvalid && (
+                  <div className="bg-red-800">Please enter a number</div>
+                )}
               </div>
             </Modal>
           </div>

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -572,7 +572,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                     if (value && typeof value === "number") {
                       setAlertThreshold(value);
                     }
-                    if (typeof value === "string") {
+                    if (value === null) {
                       toast.success("Please enter a number");
                     }
                   }}

--- a/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanComponent.tsx
@@ -537,6 +537,7 @@ const PlanComponents: FC<PlanComponentsProps> = ({
                       <Button
                         key="submit"
                         type="primary"
+                        disabled={isInvalid}
                         onClick={() => submitAlertModal(currentComponent)}
                       >
                         Create

--- a/frontend/src/components/Plans/PlanDetails/PlanDetails.tsx
+++ b/frontend/src/components/Plans/PlanDetails/PlanDetails.tsx
@@ -144,6 +144,7 @@ const PlanDetails: FC = () => {
     data: plan,
     isLoading,
     isError,
+    refetch,
   } = useQuery<PlanDetailType>(
     ["plan_detail", planId],
     () =>
@@ -239,6 +240,7 @@ const PlanDetails: FC = () => {
           <div className="mx-10">
             {plan.versions.length > 0 && (
               <SwitchVersions
+                refetch={refetch}
                 versions={plan.versions}
                 createPlanExternalLink={createPlanExternalLink}
                 deletePlanExternalLink={deletePlanExternalLink}

--- a/frontend/src/components/Plans/PlanDetails/SwitchVersions.tsx
+++ b/frontend/src/components/Plans/PlanDetails/SwitchVersions.tsx
@@ -24,6 +24,7 @@ import { useMutation, useQueryClient } from "react-query";
 interface SwitchVersionProps {
   versions: PlanVersionType[];
   plan: PlanDetailType;
+  refetch: VoidFunction;
   className: string;
   createPlanExternalLink: (link: string) => void;
   deletePlanExternalLink: (link: string) => void;
@@ -54,6 +55,7 @@ function capitalize(word: string) {
 const SwitchVersions: FC<SwitchVersionProps> = ({
   versions,
   plan,
+  refetch,
   createPlanExternalLink,
   deletePlanExternalLink,
   className,
@@ -104,7 +106,14 @@ const SwitchVersions: FC<SwitchVersionProps> = ({
       },
     }
   );
-
+  // useEffect(() => {
+  //   console.log("veif", versions);
+  //   setSelectedVersion(versions.find((x) => x.status === "active")!);
+  // }, [versions]);
+  useEffect(() => {
+    console.log("aveg", plan.versions);
+    setSelectedVersion(plan.versions.find((x) => x.status === "active")!);
+  }, [plan]);
   useEffect(() => {
     setCapitalizedState(capitalize(selectedVersion.status));
   }, [selectedVersion.status]);
@@ -136,6 +145,7 @@ const SwitchVersions: FC<SwitchVersionProps> = ({
           <div
             onClick={(e) => {
               console.log(e.target);
+              refetch();
               setSelectedVersion(version);
             }}
             className={[
@@ -180,6 +190,7 @@ const SwitchVersions: FC<SwitchVersionProps> = ({
 
         <div>
           <PlanComponents
+            refetch={refetch}
             updateBillingFrequencyMutation={updateBillingFrequency.mutate}
             plan={plan}
             components={selectedVersion.components}

--- a/frontend/src/components/Plans/PlanDetails/SwitchVersions.tsx
+++ b/frontend/src/components/Plans/PlanDetails/SwitchVersions.tsx
@@ -107,11 +107,9 @@ const SwitchVersions: FC<SwitchVersionProps> = ({
     }
   );
   // useEffect(() => {
-  //   console.log("veif", versions);
   //   setSelectedVersion(versions.find((x) => x.status === "active")!);
   // }, [versions]);
   useEffect(() => {
-    console.log("aveg", plan.versions);
     setSelectedVersion(plan.versions.find((x) => x.status === "active")!);
   }, [plan]);
   useEffect(() => {

--- a/frontend/src/components/Plans/UsageComponentForm.tsx
+++ b/frontend/src/components/Plans/UsageComponentForm.tsx
@@ -408,14 +408,14 @@ function UsageComponentForm({
     {
       title: "First Unit",
       dataIndex: "range_start",
-      width: "20%",
+      width: "17%",
       align: "center",
       editable: true,
     },
     {
       title: "Last Unit",
       dataIndex: "range_end",
-      width: "20%",
+      width: "17%",
       align: "center",
 
       editable: true,
@@ -431,7 +431,7 @@ function UsageComponentForm({
       title: "Charge Type",
       dataIndex: "type",
       editable: true,
-      width: "20%",
+      width: "17%",
       align: "center",
     },
     {
@@ -439,12 +439,12 @@ function UsageComponentForm({
       dataIndex: "cost_per_batch",
       editable: true,
       align: "center",
-      width: "15%",
+      width: "13%",
     },
     {
       title: "Units",
       dataIndex: "metric_units_per_batch",
-      width: "15%",
+      width: "13%",
       align: "center",
       editable: true,
       render: (text: any, record: Tier) => {
@@ -458,14 +458,14 @@ function UsageComponentForm({
     {
       title: "Rounding Type",
       dataIndex: "batch_rounding_type",
-      width: "15%",
+      width: "23%",
       align: "center",
       editable: true,
       render: (text: any, record: Tier) => {
         if (record.type === "flat" || record.type === "free") {
           return "-";
         } else {
-          return record.batch_rounding_type;
+          return <div>{record.batch_rounding_type}</div>;
         }
       },
     },
@@ -473,7 +473,7 @@ function UsageComponentForm({
     {
       title: "Delete",
       dataIndex: "delete",
-      width: "10%",
+      width: "8%",
       align: "center",
       render: (_, record) =>
         currentTiers.length > 1 &&

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,7 +105,9 @@ a {
 .ant-descriptions-header {
   margin-bottom: 0;
 }
-
+.ant-form-item .w-full {
+  background-color: red;
+}
 .ant-descriptions-title {
   font-size: 26px;
   line-height: 30px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,12 +105,12 @@ a {
 .ant-descriptions-header {
   margin-bottom: 0;
 }
-/* .ant-input-number-input:invalid {
+.ant-input-number-input:invalid {
   border: 2px solid red;
 }
 .ant-input-number-input-wrap:has( > .ant-input-number-input:invalid) {
   border: 2px solid red;
-} */
+}
 .ant-descriptions-title {
   font-size: 26px;
   line-height: 30px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,9 +105,12 @@ a {
 .ant-descriptions-header {
   margin-bottom: 0;
 }
-.ant-form-item .w-full {
-  background-color: red;
+/* .ant-input-number-input:invalid {
+  border: 2px solid red;
 }
+.ant-input-number-input-wrap:has( > .ant-input-number-input:invalid) {
+  border: 2px solid red;
+} */
 .ant-descriptions-title {
   font-size: 26px;
   line-height: 30px;

--- a/frontend/src/pages/CreatePlan.tsx
+++ b/frontend/src/pages/CreatePlan.tsx
@@ -262,16 +262,13 @@ const CreatePlan = () => {
           plan_duration: values.plan_duration,
           initial_version: initialPlanVersion,
         };
-        console.log(plan);
         const links = values.initial_external_links;
-        console.log(links);
         if (links?.length) {
           plan.initial_external_links = links.map((link) => ({
             source: "stripe",
             external_plan_id: link,
           }));
         }
-        console.log(plan);
         mutation.mutate(plan);
       })
       .catch((info) => {});

--- a/frontend/src/pages/CreatePlan.tsx
+++ b/frontend/src/pages/CreatePlan.tsx
@@ -262,14 +262,16 @@ const CreatePlan = () => {
           plan_duration: values.plan_duration,
           initial_version: initialPlanVersion,
         };
-
+        console.log(plan);
         const links = values.initial_external_links;
+        console.log(links);
         if (links?.length) {
           plan.initial_external_links = links.map((link) => ({
             source: "stripe",
             external_plan_id: link,
           }));
         }
+        console.log(plan);
         mutation.mutate(plan);
       })
       .catch((info) => {});


### PR DESCRIPTION
## Closes 
Closes LOT-477. Closes LOT-476. Closes LOT-475. Closes LOT-474. Closes LOT-473.

## Description 
This MR addresses UI bugs, nits etc. 

### LOT-477 
- [ ]  Go to "Plans" > Select a plan (with one version). 
- [ ] Click "Add Alert" Enter text e.g. "Osa" It should show a toast requesting you input a number and the border should change. 

### LOT-476
- [ ] Add the alert. The page should automatically update. 

### LOT-475 
- [ ] Go to the dashboard. Switch environments. Close the side drawer / slideover component. The earned revenue, previous period, subscriptions

### LOT-474 
- [ ] Go to plans > Create a new plan. 
- [ ] Link external IDs should not span fully. 

### LOT-473 
- [ ] On the same page, click "Add component". 
- [ ] Change charge type to "charge unit" and rounding unit's select options should be wide enough i.e. show all options without "..." wrapping. 