### PR TITLE
Resolve "Bug - Inconsistent Styling Compared to Figma For Addons Detail & Create addons"

### DIFF
--- a/frontend/src/components/Addons/AddonsDetails/AddOnComponents.tsx
+++ b/frontend/src/components/Addons/AddonsDetails/AddOnComponents.tsx
@@ -5,8 +5,9 @@ import { Table, Typography, Modal, Button, InputNumber } from "antd";
 import { Plan } from "../../../api/api";
 import { AddonType } from "../../../types/addon-type";
 import { AlertType, CreateAlertType } from "../../../types/alert-type";
-import { Component } from "../../../types/plan-type";
+import { Component, Tier } from "../../../types/plan-type";
 import Select from "../../base/Select/Select";
+import { CurrencyType } from "../../../types/pricing-unit-type";
 interface AddOnsComponentsProps {
   components?: Component[];
   plan: AddonType;

--- a/frontend/src/components/Addons/AddonsDetails/AddOnFeatures.tsx
+++ b/frontend/src/components/Addons/AddonsDetails/AddOnFeatures.tsx
@@ -13,9 +13,7 @@ const AddOnFeatures: FC<AddOnFeaturesFeaturesProps> = ({ features }) => {
   const windowWidth = useMediaQuery();
   return (
     <div className="min-h-[200px] mt-4 min-w-[246px] p-8 cursor-pointer font-main rounded-sm bg-card ">
-      <Typography.Title className="!text-[18px]" level={2}>
-        Features
-      </Typography.Title>
+      <Typography.Title className="!text-[18px]">Features</Typography.Title>
       <div className="h-[1.5px] mt-6 bg-card-divider mb-2" />
       <div className="grid gap-6 grid-cols-1 xl:grid-cols-4">
         {features && features.length > 0 ? (
@@ -44,7 +42,9 @@ const AddOnFeatures: FC<AddOnFeaturesFeaturesProps> = ({ features }) => {
             </div>
           ))
         ) : (
-          <div className="text-card-grey">No features added</div>
+          <div className="text-card-grey whitespace-nowrap">
+            No features added
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/Addons/AddonsDetails/AddOnInfo.tsx
+++ b/frontend/src/components/Addons/AddonsDetails/AddOnInfo.tsx
@@ -28,50 +28,57 @@ const AddOnInfo = ({ addOnInfo }: AddOnInfoProps) => {
       </Typography.Title>
       <div className=" w-full h-[1.5px] mt-6 bg-card-divider mb-2" />
       <div className="grid  items-center grid-cols-1 md:grid-cols-[repeat(2,_minmax(0,_0.3fr))]">
-        <div className="w-[240px]">
-          <div className="flex items-center justify-between text-card-text gap-2 mb-1">
-            <div className="font-normal whitespace-nowrap leading-4">
+        <div className="w-[256px]">
+          <div className="flex items-center justify-between text-card-text !gap-20 mb-1">
+            <div className="font-normal text-card-text font-alliance whitespace-nowrap leading-4">
               Add-On ID
             </div>
-            <div className="flex gap-1 text-card-grey font-menlo">
+            <div className="flex gap-1 !text-card-grey font-menlo">
               {" "}
               <div>
-                {createShortenedText(addOnInfo.addon_id, windowWidth >= 2500)}
+                {createShortenedText(
+                  addOnInfo.addon_id as string,
+                  windowWidth >= 2500
+                )}
               </div>
-              <CopyText showIcon onlyIcon textToCopy={addOnInfo.addon_id} />
+              <CopyText
+                showIcon
+                onlyIcon
+                textToCopy={addOnInfo.addon_id as string}
+              />
             </div>
           </div>
-          <div className="flex items-center text-card-text justify-between mb-1">
-            <div className=" font-normal whitespace-nowrap leading-4">
+          <div className="flex items-center  text-card-text justify-between mb-1">
+            <div className="text-card-text font-normal font-alliance whitespace-nowrap leading-4">
               Price
             </div>
-            <div className="flex gap-1">
+            <div className="flex gap-1 text-left">
               {" "}
-              <div className="text-gold">{`${addOnInfo.currency?.symbol}${addOnInfo.flat_rate}`}</div>
+              <div className="text-gold Inter">{`${addOnInfo.currency?.symbol}${addOnInfo.flat_rate}`}</div>
             </div>
           </div>
         </div>
 
-        <div className="w-[240px]">
+        <div className="w-[256px]">
           <div className="flex items-center text-card-text justify-between gap-2 mb-1">
-            <div className=" font-bold font-alliance whitespace-nowrap leading-4">
+            <div className=" font-alliance font-normal whitespace-nowrap leading-4">
               Type
             </div>
             <div className="flex gap-1 ">
               {" "}
-              <div className="!text-card-grey">
-                {constructBillType(addOnInfo.addon_type)}
+              <div className="!text-card-grey Inter">
+                {capitalize(constructBillType(addOnInfo.addon_type))}
               </div>
             </div>
           </div>
 
           <div className="flex items-center justify-between text-card-text gap-2 mb-1">
-            <div className="font-bold font-alliance whitespace-nowrap leading-4">
+            <div className="font-alliance font-normal whitespace-nowrap leading-4">
               Billing Frequency
             </div>
             <div>
-              <div className="!text-card-grey">
-                {constructBillType(addOnInfo.billing_frequency)}
+              <div className="!text-card-grey Inter">
+                {constructBillType(addOnInfo.billing_frequency as string)}
               </div>
             </div>
           </div>

--- a/frontend/src/components/Addons/AddonsDetails/AddonDetails.tsx
+++ b/frontend/src/components/Addons/AddonsDetails/AddonDetails.tsx
@@ -79,6 +79,26 @@ const AddonDetails: FC = () => {
                 </div>
               </div>
             }
+            hasBackButton
+            aboveTitle
+            backButton={
+              <div>
+                <Button
+                  onClick={() => navigate(-1)}
+                  type="primary"
+                  size="large"
+                  key="create-custom-plan"
+                  style={{
+                    background: "#F5F5F5",
+                    borderColor: "#F5F5F5",
+                  }}
+                >
+                  <div className="flex items-center justify-between text-black">
+                    <div>&larr; Go back</div>
+                  </div>
+                </Button>
+              </div>
+            }
           ></PageLayout>
           <div className="mx-10">
             <div className="bg-white mb-6 flex flex-col py-4 px-10 rounded-lg space-y-12">
@@ -87,9 +107,12 @@ const AddonDetails: FC = () => {
               </div>
 
               <div className="grid gap-18 grid-cols-1  md:grid-cols-2 w-full">
-              {addon?.components.length > 0 && (
-                <AddOnComponents 
-                  refetch={refetch} plan={addon} components={addon?.components} />
+                {addon?.components.length > 0 && (
+                  <AddOnComponents
+                    refetch={refetch}
+                    plan={addon}
+                    components={addon?.components}
+                  />
                 )}
                 <AddOnFeatures features={addon?.features} />
               </div>

--- a/frontend/src/components/base/Heading/Heading.tsx
+++ b/frontend/src/components/base/Heading/Heading.tsx
@@ -8,9 +8,14 @@ import useToggleSlideOver from "../../../stores/useToggleSlideOver";
 interface HeadingProps {
   hasBackButton?: boolean;
   backButton?: React.ReactNode;
+  aboveTitle?: boolean;
 }
 
-const Heading: React.FC<HeadingProps> = ({ hasBackButton, backButton }) => {
+const Heading: React.FC<HeadingProps> = ({
+  hasBackButton,
+  backButton,
+  aboveTitle,
+}) => {
   const { current_user, environment } = useGlobalStore((state) => state.org);
   const { pathname } = useLocation();
   const setOpen = useToggleSlideOver((state) => state.setOpen);
@@ -57,6 +62,7 @@ const Heading: React.FC<HeadingProps> = ({ hasBackButton, backButton }) => {
             </Badge>
           </div>
           <div
+            aria-hidden
             onClick={setOpen}
             className={`flex gap-4 items-center p-4 ${
               isPlansPage ? "hover:bg-gold-50" : "hover:bg-white"
@@ -82,7 +88,7 @@ const Heading: React.FC<HeadingProps> = ({ hasBackButton, backButton }) => {
           </div>
         </div>
       </div>
-      {hasBackButton && backButton}
+      {hasBackButton && !aboveTitle && backButton}
       <div className=" h-[1.5px] w-full bg-red" />
     </div>
   );

--- a/frontend/src/components/base/PageLayout.tsx
+++ b/frontend/src/components/base/PageLayout.tsx
@@ -1,5 +1,4 @@
 import { Layout, PageHeader, PageHeaderProps } from "antd";
-// @ts-ignore
 import React from "react";
 import SlideOver from "../SlideOver/SlideOver";
 import Heading from "./Heading/Heading";
@@ -7,27 +6,34 @@ import Heading from "./Heading/Heading";
 interface PageLayoutProps extends PageHeaderProps {
   hasBackButton?: boolean;
   backButton?: React.ReactNode;
+  aboveTitle?: boolean;
 }
 export const PageLayout = ({
   children,
   hasBackButton,
   backButton,
+  aboveTitle,
   ...props
 }: PageLayoutProps) => {
   return (
     <div>
       <SlideOver />
 
-      <Heading />
+      <Heading
+        hasBackButton={hasBackButton}
+        aboveTitle={aboveTitle}
+        backButton={backButton}
+      />
       <PageHeader />
 
       <div className="mx-10 mt-16">
         <div className="flex items-center justify-between mb-6">
           {props.title ? (
             <h1
-              className={hasBackButton ? "font-main mt-20 mx-10" : "font-main"}
+              className={hasBackButton ? "font-main  mx-10" : "font-main"}
             >
-              {props.title}
+              {hasBackButton && aboveTitle && backButton}
+              <div className={hasBackButton ? "mt-12" : ""}>{props.title}</div>
             </h1>
           ) : (
             <h1>{props.title}</h1>

--- a/frontend/src/pages/CreateAddOns.tsx
+++ b/frontend/src/pages/CreateAddOns.tsx
@@ -220,7 +220,11 @@ const CreateAddOns = () => {
     };
     mutation.mutate(addons);
   };
-  if ( addon_type === "usage" ) {
+  if (
+    (addon_type === "usage" && billing_frequency === "one_time") ||
+    (addon_type === "flat_fee" && billing_frequency === "recurring")
+  ) {
+    console.log("yasdh");
     card = (
       <Card
         title="Added Components"
@@ -272,6 +276,27 @@ const CreateAddOns = () => {
           Preview & publish
         </Button>,
       ]}
+      hasBackButton
+      aboveTitle
+      backButton={
+        <div className="mt-10">
+          <Button
+            onClick={() => navigate(-1)}
+            type="primary"
+            size="large"
+            className="ml-[10px] mt-[32px]"
+            key="create-custom-plan"
+            style={{
+              background: "#F5F5F5",
+              borderColor: "#F5F5F5",
+            }}
+          >
+            <div className="flex items-center justify-between text-black">
+              <div>&larr; Go back</div>
+            </div>
+          </Button>
+        </div>
+      }
     >
       <Form.Provider>
         <Form
@@ -285,7 +310,16 @@ const CreateAddOns = () => {
           labelAlign="left"
         >
           <div className="grid gap-12 grid-cols-1  md:grid-cols-3">
-            <Card className="col-span-1" title="Add-on Information">
+            <Card
+              style={{
+                borderRadius: "0.5rem",
+                borderWidth: "2px",
+                borderColor: "#EAEAEB",
+                borderStyle: "solid",
+              }}
+              className="col-span-1"
+              title="Add-on Information"
+            >
               <Form.Item name="add-on name">
                 <label className="mb-4 required">Add-on Name </label>
                 <Input
@@ -333,7 +367,7 @@ const CreateAddOns = () => {
                 </Select>
               </Form.Item>
               <div className="grid grid-cols-2 gap-6 mt-2 mb-2">
-                <Form.Item name="base_cost">
+                <Form.Item name="base cost">
                   <label className="mb-4 required">Base Cost</label>
                   <InputNumber
                     className="w-full"
@@ -371,7 +405,7 @@ const CreateAddOns = () => {
 
               {billing_frequency === "recurring" && (
                 <Form.Item name="recurring_flat_fee_timing">
-                  <label className="mb-4 nowrap required"> Base Cost Billing Type</label>
+                  <label className="mb-4 nowrap required"> Billing Type</label>
                   <Select
                     onChange={(e) => setRecurringFlatFeeTiming(e)}
                     className="w-full"
@@ -387,6 +421,7 @@ const CreateAddOns = () => {
                 </Form.Item>
               )}
 
+              {showInvoicing && (
                 <Form.Item name="invoice_when">
                   <label className="mb-4">Invoicing When</label>
                   <Select
@@ -402,13 +437,14 @@ const CreateAddOns = () => {
                     </Select.Option>
                   </Select>
                 </Form.Item>
+              )}
             </Card>
 
             <div className="col-span-2">
               {card}
 
               <Card
-                className="w-full !mt-8"
+                className="w-full"
                 title="Added Features"
                 style={{
                   borderRadius: "0.5rem",


### PR DESCRIPTION
## Closes 
Closes LOT-528. 

## Description 
This MR fixes the bugs in LOT-528. It fixes some alignment issues and font stuff, adds a button and some other stuff.

## Testing Plan
- [ ] Log onto the app 
- [ ] Navigate to add-ons 
- [ ] Create an add-on 
- [ ] borders should match for add-on information and added features
- [ ] the tops are misaligned here for both add-on information and added features
- [ ] There should be a "go back" button. 
- [ ] Go to the individual Add-on page 
- [ ] Title should be aligned. 
- [ ] There should be a back button. 
- [ ] Component headings should have the same font. 

Plan Details have no go back cuz in one of the Looms we decided to remove it. Don't think we'd have gone live on PH without it. There's also a few design elements missing as requested. I think for posterity we document Looms (probably via transcripts) just so we can look back on certain decisions.

