### PR TITLE
Fix unnecessary example .env variable quotes.

### DIFF
--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -9,10 +9,10 @@ ADMIN_PASSWORD=change_me
 DEBUG=True
 SELF_HOSTED=False
 DOCKERIZED=True
-DJANGO_SETTINGS_MODULE="lotus.settings"
+DJANGO_SETTINGS_MODULE=lotus.settings
 
 NODE_ENV=development
-VITE_API_URL="http://localhost:8000/"
+VITE_API_URL=http://localhost:8000/
 
 STRIPE_LIVE_SECRET_KEY=sk_live_
 STRIPE_LIVE_CLIENT=ca_
@@ -20,7 +20,7 @@ STRIPE_TEST_SECRET_KEY=sk_test_
 STRIPE_TEST_CLIENT=ca_
 STRIPE_WEBHOOK_SECRET=whsec_
 
-KAFKA_URL="redpanda:29092"
+KAFKA_URL=redpanda:29092
 
 SVIX_JWT_SECRET=change_me
 

--- a/env/.env.prod.example
+++ b/env/.env.prod.example
@@ -8,11 +8,11 @@ ADMIN_EMAIL=change_me
 ADMIN_PASSWORD=change_me
 SELF_HOSTED=True
 DOCKERIZED=True
-DJANGO_SETTINGS_MODULE="lotus.settings"
+DJANGO_SETTINGS_MODULE=lotus.settings
 PRODUCT_ANALYTICS_OPT_IN=True
 
 NODE_ENV=production
-VITE_API_URL="http://localhost/"
+VITE_API_URL=http://localhost/
 
 STRIPE_LIVE_SECRET_KEY=sk_live_
 STRIPE_LIVE_CLIENT=ca_
@@ -20,7 +20,7 @@ STRIPE_TEST_SECRET_KEY=sk_test_
 STRIPE_TEST_CLIENT=ca_
 STRIPE_WEBHOOK_SECRET=whsec_
 
-KAFKA_URL="redpanda:29092"
+KAFKA_URL=redpanda:29092
 
 SVIX_JWT_SECRET=change_me
 


### PR DESCRIPTION
If the previous settings are copied for a Dockerized version of the app, these errors show up:

1. ![image](https://user-images.githubusercontent.com/94221138/218299410-5b83914b-4f6d-4eae-9a52-09080b8560b9.png)
 
2. ![image](https://user-images.githubusercontent.com/94221138/218299428-8725bb4d-db66-49ec-9cf7-361aed451268.png)

These errors did not show up when running the app with `dev.sh`

This PR fixes that. 