### PR TITLE
Resolve "Bug - Cancel/Add addon modal is glitchy with many plans (more than 10)"

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -27,5 +27,29 @@ module.exports = {
   },
   rules: {
     // Add your own rules here to override ones from the extended configs.
+    "import/no-unresolved": "off",
+    camelcase: [
+      "error",
+      {
+        properties: "never",
+        ignoreDestructuring: true,
+        ignoreImports: true,
+        ignoreGlobals: true,
+      },
+    ],
+    "no-shadow": ["error", { hoist: "never", ignoreOnInitialization: true }],
+    "react/function-component-definition": [
+      2,
+      {
+        namedComponents: ["arrow-function", "function-declaration"],
+        unnamedComponents: "arrow-function",
+      },
+    ],
+    "react/require-default-props": [
+      0,
+      {
+        functions: "ignore",
+      },
+    ],
   },
 };

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -51,5 +51,11 @@ module.exports = {
         functions: "ignore",
       },
     ],
+    "react/jsx-filename-extension": [1, { extensions: [".tsx", ".ts"] }],
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      { js: "never", jsx: "never", ts: "never", tsx: "never" },
+    ],
   },
 };

--- a/frontend/src/components/Customers/CancelMenu.tsx
+++ b/frontend/src/components/Customers/CancelMenu.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Radio } from "antd";
+
+const subscriptionCancellationOptions = [
+  { name: "Cancel and Bill  Now", type: "bill_now" },
+  { name: "Cancel Renewal", type: "remove_renewal" },
+];
+const CancelMenuComponent = ({
+  setCancelSubType,
+}: {
+  setCancelSubType: (e: "bill_now" | "remove_renewal") => void;
+}) => (
+  <div>
+    <p className="text-base Inter">
+      If you cancel a plan the customer will lose it permanently, and you
+      won&apos;t be able to recover it. Do you want to continue?
+    </p>
+    <Radio.Group
+      onChange={(e) => setCancelSubType(e.target.value)}
+      buttonStyle="solid"
+    >
+      <div className="flex flex-row items-center justify-center gap-4">
+        {subscriptionCancellationOptions.map((options) => (
+          <div
+            key={options.type}
+            className="flex items-center justify-center gap-2"
+          >
+            <Radio.Button
+              value={options.type}
+              defaultChecked={options.type === "bill_now"}
+            >
+              {options.name}
+            </Radio.Button>
+          </div>
+        ))}
+      </div>
+    </Radio.Group>
+  </div>
+);
+const CancelMenu = React.memo(CancelMenuComponent);
+
+export default CancelMenu;

--- a/frontend/src/components/Customers/CustomerDetail.tsx
+++ b/frontend/src/components/Customers/CustomerDetail.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable camelcase */
 import React, { useState } from "react";
-import { Form, Tabs, Modal, Button } from "antd";
+import { Tabs, Button } from "antd";
 import {
   useMutation,
   useQueryClient,
@@ -20,23 +21,23 @@ import {
 import LoadingSpinner from "../LoadingSpinner";
 import { Customer, Plan, PricingUnits } from "../../api/api";
 import SubscriptionView from "./CustomerSubscriptionView";
-import { CustomerType, DetailPlan } from "../../types/customer-type";
+import { CustomerType } from "../../types/customer-type";
 import "./CustomerDetail.css";
 import CustomerInvoiceView from "./CustomerInvoices";
 import CustomerBalancedAdjustments from "./CustomerBalancedAdjustments";
 import { CustomerCostType } from "../../types/revenue-type";
 import CustomerInfoView from "./CustomerInfo";
 
-import CopyText from "../base/CopytoClipboard";
 import { CurrencyType } from "../../types/pricing-unit-type";
 import { PageLayout } from "../base/PageLayout";
+import { QueryErrors } from "../../types/error-response-types";
 
 type CustomerDetailsParams = {
   customerId: string;
 };
 function CustomerDetail() {
   const { customerId: customer_id } = useParams<CustomerDetailsParams>();
-  const [form] = Form.useForm();
+
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [startDate, setStartDate] = useState<string>(
@@ -51,25 +52,24 @@ function CustomerDetail() {
   const { data: pricingUnits }: UseQueryResult<CurrencyType[]> = useQuery<
     CurrencyType[]
   >(["pricing_unit_list"], () => PricingUnits.list().then((res) => res));
-  const { data, isLoading, refetch }: UseQueryResult<CustomerType> =
+  const { data, refetch }: UseQueryResult<CustomerType> =
     useQuery<CustomerType>(["customer_detail", customer_id], () =>
       Customer.getCustomerDetail(customer_id as string).then((res) => res)
     );
 
-  const { data: cost_analysis, isLoading: cost_analysis_loading } =
-    useQuery<CustomerCostType>(
-      ["customer_cost_analysis", customer_id, startDate, endDate],
-      () => Customer.getCost(customer_id as string, startDate, endDate),
-      {
-        enabled: true,
-        placeholderData: {
-          per_day: [],
-          total_revenue: 0,
-          total_cost: 0,
-          margin: 0,
-        },
-      }
-    );
+  const { data: cost_analysis } = useQuery<CustomerCostType>(
+    ["customer_cost_analysis", customer_id, startDate, endDate],
+    () => Customer.getCost(customer_id as string, startDate, endDate),
+    {
+      enabled: true,
+      placeholderData: {
+        per_day: [],
+        total_revenue: 0,
+        total_cost: 0,
+        margin: 0,
+      },
+    }
+  );
 
   const createSubscriptionMutation = useMutation(
     (post: CreateSubscriptionType) => Customer.createSubscription(post),
@@ -82,7 +82,7 @@ function CustomerDetail() {
         refetch();
         toast.success("Subscription created successfully");
       },
-      onError: (error: any) => {
+      onError: (error: QueryErrors) => {
         toast.error(error.response.data.title);
       },
     }
@@ -102,7 +102,7 @@ function CustomerDetail() {
         refetch();
         toast.success("Subscription cancelled successfully");
       },
-      onError: (error: any) => {
+      onError: (error: QueryErrors) => {
         toast.error(error.response.data.title);
       },
     }
@@ -120,7 +120,7 @@ function CustomerDetail() {
         refetch();
         toast.success("Subscription switched successfully");
       },
-      onError: (error: any) => {
+      onError: (error: QueryErrors) => {
         toast.error(error.response.data.title);
       },
     }
@@ -135,7 +135,7 @@ function CustomerDetail() {
         refetch();
         toast.success("Subscription auto renew turned off");
       },
-      onError: (error: any) => {
+      onError: (error: QueryErrors) => {
         toast.error(error.response.data.title);
       },
     }
@@ -180,7 +180,7 @@ function CustomerDetail() {
   const createSubscription = (props: CreateSubscriptionType) => {
     createSubscriptionMutation.mutate(props);
   };
-  console.log(data);
+
   return (
     <PageLayout
       title={data?.customer_name}

--- a/frontend/src/components/Customers/CustomerInvoices.tsx
+++ b/frontend/src/components/Customers/CustomerInvoices.tsx
@@ -25,7 +25,6 @@ const getPdfUrl = async (invoice: InvoiceType) => {
     downloadFile(pdfUrl);
   } catch (err) {
     toast.error("Error downloading file");
-    console.log(err);
   }
 };
 

--- a/frontend/src/components/Customers/CustomerSubscriptionView.tsx
+++ b/frontend/src/components/Customers/CustomerSubscriptionView.tsx
@@ -23,6 +23,7 @@ import {
   UseQueryResult,
 } from "react-query";
 import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
 import { PlanType } from "../../types/plan-type";
 import dayjs from "dayjs";
 import {
@@ -47,7 +48,7 @@ import DropdownComponent from "../base/Dropdown/Dropdown";
 import { DraftInvoiceType } from "../../types/invoice-type";
 import { Addon, Customer, Invoices } from "../../api/api";
 import { AddonType, AddonSubscriptionType } from "../../types/addon-type";
-import { useNavigate } from "react-router-dom";
+
 import ChevronDown from "../base/ChevronDown";
 
 interface Props {

--- a/frontend/src/components/Customers/CustomerSubscriptionView.tsx
+++ b/frontend/src/components/Customers/CustomerSubscriptionView.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable no-shadow */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable no-nested-ternary */
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable camelcase */
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   Form,

--- a/frontend/src/components/Customers/DraftInvoice.tsx
+++ b/frontend/src/components/Customers/DraftInvoice.tsx
@@ -1,4 +1,10 @@
-import React, { FC, useState } from "react";
+/* eslint-disable no-shadow */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/display-name */
+/* eslint-disable func-names */
+/* eslint-disable react/no-unstable-nested-components */
+/* eslint-disable camelcase */
+import React, { FC } from "react";
 import { useQuery } from "react-query";
 import { Table } from "antd";
 import dayjs from "dayjs";
@@ -7,6 +13,7 @@ import { Invoices } from "../../api/api";
 import {
   DraftInvoiceType,
   ExternalLineItem,
+  IndividualDraftInvoiceType,
   LineItem,
 } from "../../types/invoice-type";
 import CustomerCard from "./Card/CustomerCard";
@@ -15,41 +22,25 @@ interface Props {
   customer_id: string;
 }
 
-const addKeysToLineItems = (lineItems: ExternalLineItem[]) => {
-  return lineItems.map((lineItem, index) => {
-    return { ...lineItem, key: index };
-  });
-};
+const addKeysToLineItems = (lineItems: ExternalLineItem[]) =>
+  lineItems.map((lineItem, index) => ({ ...lineItem, key: index }));
 
 const DraftInvoice: FC<Props> = ({ customer_id }) => {
-  const { data: invoiceData, isLoading: invoiceLoading } =
-    useQuery<DraftInvoiceType>(
-      ["draft_invoice", customer_id],
-      () => Invoices.getDraftInvoice(customer_id),
-      {
-        refetchInterval: 10000,
-      }
-    );
-  const [expandedRowKey, setExpandedRowKey] = useState(null);
+  const { data: invoiceData } = useQuery<DraftInvoiceType>(
+    ["draft_invoice", customer_id],
+    () => Invoices.getDraftInvoice(customer_id)
+  );
 
-  const handleExpand = (expanded, record) => {
-    if (expanded) {
-      setExpandedRowKey(record.key);
-    } else {
-      setExpandedRowKey(null);
-    }
-  };
-
-  const expandedRowRender = (invoice: ExternalLineItem) => {
-    return (record) => {
+  const expandedRowRender =
+    (invoice: IndividualDraftInvoiceType) => (record) => {
       const columns: TableColumnsType<LineItem> = [
         {
-          title: "Item",
+          title: "ITEM",
           dataIndex: "name",
           key: "name",
         },
         {
-          title: "Dates",
+          title: "DATES",
           dataIndex: "start_date",
           key: "date",
           render: (_, record) => (
@@ -61,7 +52,7 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
           ),
         },
         {
-          title: "Quantity",
+          title: "QUANTITY",
           dataIndex: "quantity",
           render: (_, record) => (
             <div className="flex flex-col">
@@ -70,7 +61,7 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
           ),
         },
         {
-          title: "Subtotal",
+          title: "SUBTOTAL",
           dataIndex: "subtotal",
           render: (_, record) => (
             <div className="flex flex-col">
@@ -80,7 +71,7 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
           ),
         },
         {
-          title: "Billing Type",
+          title: "BILLING TYPE",
           dataIndex: "billing_type",
         },
       ];
@@ -91,12 +82,9 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
           rowClassName="bg-card"
           dataSource={record.sub_items}
           pagination={false}
-          onExpand={(expanded) => handleExpand(expanded, record)}
-          expandedRowKeys={expandedRowKey === record.key ? [record.key] : []}
         />
       );
     };
-  };
 
   return (
     <div>
@@ -105,8 +93,11 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
       </h2>
       {invoiceData?.invoices !== null &&
         invoiceData?.invoices !== undefined &&
-        invoiceData.invoices.map((invoice, index) => (
-          <div key={index} className="grid gap-12 grid-cols-1  md:grid-cols-3">
+        invoiceData.invoices.map((invoice) => (
+          <div
+            key={invoice.cost_due}
+            className="grid gap-12 grid-cols-1  md:grid-cols-3"
+          >
             <CustomerCard className="col-span-1 h-[200px] shadow-none">
               <CustomerCard.Container>
                 <CustomerCard.Block>
@@ -153,9 +144,6 @@ const DraftInvoice: FC<Props> = ({ customer_id }) => {
                 pagination={false}
                 expandable={{
                   expandedRowRender: expandedRowRender(invoice),
-                  onExpand: (expanded, record) =>
-                    handleExpand(expanded, record),
-                  expandedRowKeys: [expandedRowKey],
                 }}
                 columns={[
                   {

--- a/frontend/src/components/Customers/DraftInvoice.tsx
+++ b/frontend/src/components/Customers/DraftInvoice.tsx
@@ -28,7 +28,8 @@ const addKeysToLineItems = (lineItems: ExternalLineItem[]) =>
 const DraftInvoice: FC<Props> = ({ customer_id }) => {
   const { data: invoiceData } = useQuery<DraftInvoiceType>(
     ["draft_invoice", customer_id],
-    () => Invoices.getDraftInvoice(customer_id)
+    () => Invoices.getDraftInvoice(customer_id),
+    { refetchInterval: 10000 }
   );
 
   const expandedRowRender =

--- a/frontend/src/components/Customers/SwitchMenu.tsx
+++ b/frontend/src/components/Customers/SwitchMenu.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable camelcase */
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable no-shadow */
+import React from "react";
+import { Form, Cascader, Input } from "antd";
+import { DefaultOptionType } from "antd/lib/select";
+import { SubscriptionType } from "../../types/subscription-type";
+
+interface ChangeOption {
+  value:
+    | "change_subscription_plan"
+    | "end_current_subscription_and_bill"
+    | "end_current_subscription_dont_bill";
+  label: string;
+  disabled?: boolean;
+}
+interface PlanOption {
+  value: string;
+  label: string;
+  children?: ChangeOption[];
+  disabled?: boolean;
+}
+const filter = (inputValue: string, path: DefaultOptionType[]) =>
+  (path[0].label as string).toLowerCase().indexOf(inputValue.toLowerCase()) >
+  -1;
+
+const displayRender = (labels: string[]) => labels[labels.length - 1];
+
+const SwitchMenuComponent = ({
+  plan_id,
+  subscription_filters,
+  subscriptions,
+  plansWithSwitchOptions,
+  setCascaderOptions,
+}: {
+  plan_id: string;
+  subscription_filters: SubscriptionType["subscription_filters"];
+  subscriptions: SubscriptionType[];
+  plansWithSwitchOptions: (plan_id: string) => PlanOption[] | undefined;
+  setCascaderOptions: (args: {
+    value: string;
+    plan_id: string;
+    subscriptionFilters: {
+      value: string;
+      property_name: string;
+    }[];
+  }) => void;
+}) => (
+  <div>
+    <Form.Item>
+      <label htmlFor="addon_id" className="mb-4 required">
+        Current Plan
+      </label>
+      <Input
+        className="!mt-2"
+        placeholder={
+          subscriptions.filter((el) => el.billing_plan.plan_id === plan_id)[0]
+            .billing_plan.plan_name
+        }
+        disabled
+      />
+    </Form.Item>
+    <Form.Item>
+      <label htmlFor="addon_id" className="mb-4 required">
+        New Plan
+      </label>
+      <div>
+        <Cascader
+          className="!w-[332px] !mt-2"
+          options={plansWithSwitchOptions(plan_id)}
+          onChange={(value) =>
+            setCascaderOptions({
+              value: value[0] as string,
+              plan_id,
+              subscriptionFilters: subscription_filters,
+            })
+          }
+          expandTrigger="hover"
+          placeholder="Please select"
+          showSearch={{ filter }}
+          displayRender={displayRender}
+          changeOnSelect
+          style={{ width: "80%" }}
+        />
+      </div>
+    </Form.Item>
+  </div>
+);
+
+const SwitchMenu = React.memo(SwitchMenuComponent);
+
+export default SwitchMenu;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,6 +96,7 @@ a {
   font-size: 26px;
   line-height: 100%;
 }
+
 .ant-modal.font-alliance > .ant-modal-content > .ant-modal-header > .ant-modal-title{
 font-size: 24px;
 }


### PR DESCRIPTION
## Closes 
Closes LOT-566. 

## Description 
This PR fixes the bug in LOT-566 where if you had >=10 plans in the subscription view of a plan, triggering the modal would cause it to flicker. 

## Testing 
- [ ] Log onto the app. 
- [ ] Go to customers. select one. 
- [ ] Attach plans till the total number is 10 or more. 
- [ ] Triggering the modal should not cause it to flicker. 

