### PR TITLE
Update docs to use correct path for running tests and checking code style

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -55,13 +55,13 @@ If you make any changes to the backend settings or the environment variables, yo
 1. Run tests
 
 ```bash
-chmod +x ./scripts/run-tests-docker.sh  && ./scripts/run-tests-docker.sh
+chmod +x ./backend/scripts/run-tests-docker.sh  && ./backend/scripts/run-tests-docker.sh
 ```
 
 2. Check the python code style
 
 ```bash
-chmod +x ./scripts/run-codestyle-docker.sh  && ./scripts/run-codestyle-docker.sh
+chmod +x ./backend/scripts/run-codestyle-docker.sh  && ./backend/scripts/run-codestyle-docker.sh
 ```
 
 #### Local Development Env variables


### PR DESCRIPTION
This PR updates the contributing docs to reflect that the `run-tests-docker.sh` and `run-codestyle-docker.sh` scripts are located under the `backend/scripts/` directory.