### PR TITLE
Fix integrations page not loading when Nango key is missing

### DIFF
--- a/frontend/src/components/Settings/settings/tabs/IntegrationsTab.tsx
+++ b/frontend/src/components/Settings/settings/tabs/IntegrationsTab.tsx
@@ -56,14 +56,13 @@ const IntegrationsTab: FC = () => {
       .catch((err) => undefined)
   );
 
-  var nango;
-
   const org = useGlobalStore((state) => state.org);
-  if ((import.meta as any).env.VITE_NANGO_PK === (undefined || "change_me")) {
-    nango = false;
-  } else {
+
+  let nango = false;
+  const nangoPK = (import.meta as any).env.VITE_NANGO_PK;
+  if (nangoPK && nangoPK !== "change_me") {
     nango = new Nango({
-      publicKey: (import.meta as any).env.VITE_NANGO_PK,
+      publicKey: nangoPK,
       debug: false,
     }); // Nango Cloud
   }


### PR DESCRIPTION
The integrations page does not load if `VITE_NANGO_PK` is undefined, and returns a JS error: "You should specify a Public Key when using Nango Cloud (cf. documentation)."

In the original version, `(undefined || "change_me")` always evaluates to `"change_me"`, so the conditional doesn't work as intended.