### PR TITLE
Workaround for vite build exceeding available memory during Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@
 # ---------------------------------------
 FROM node:18.11.0-alpine AS development
 WORKDIR /frontend
+ENV NODE_OPTIONS=--max_old_space_size=2048
 COPY package*.json yarn.lock tsconfig.json \
     vite.config.ts tsconfig.node.json postcss.config.cjs\
     tailwind.config.cjs ./


### PR DESCRIPTION
This increases node's max_old_space_size for the frontend container, because vite build step consistently exceeds available memory.

It might be better to figure out why rollup is using this much memory. Most likely to build source maps for ant-design and other large deps.