### PR TITLE
Use python:3.9-bullseye as docker image for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # ---------------------------------------
 # Build
 # ---------------------------------------
-FROM python:3.9 AS build
+FROM python:3.9-bullseye AS build
 ENV PYTHONUNBUFFERED 1
 WORKDIR /lotus
 # pip install optimization


### PR DESCRIPTION
It was previously only "python:3.9". Recently debian bookworm become the stable version, resulting in in "python:3.9" to pull down "python:3.9-bookworm". This makes "apt install netcat" command to fail.

```
[1/3] STEP 4/11: RUN apt-get update && apt-get install -y netcat
Get:1 http://deb.debian.org/debian bookworm InRelease [147 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8904 kB]
Get:5 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [31.6 kB]
Fetched 9183 kB in 5s (1877 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47
  ```
  
  I'm assuming lotus was developed with bullseye. So this should fix the build.