### PR TITLE
make frontend description required

### DIFF
--- a/frontend/src/pages/CreateAddOns.tsx
+++ b/frontend/src/pages/CreateAddOns.tsx
@@ -356,7 +356,7 @@ function CreateAddOns() {
                 />
               </Form.Item>
               <Form.Item name="description">
-                <label className="mb-4">Description </label>
+                <label className="mb-4 required">Description </label>
                 <Input
                   className="w-full"
                   type="textarea"


### PR DESCRIPTION
Resolves https://github.com/uselotus/lotus/issues/779 . Frontend field was marked as not required when it is required.