### PR TITLE
Fix docker compose db configuration

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -5,7 +5,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./pgdata_dev:/var/lib/postgresql/data
+      - pgdata_dev:/var/lib/postgresql/data
     env_file:
       - ./env/.env.dev
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -5,7 +5,7 @@ services:
     expose:
       - 5432
     volumes:
-      - ./pgdata_prod:/var/lib/postgresql/data
+      - pgdata_prod:/var/lib/postgresql/data
     env_file:
       - ./env/.env.prod
 


### PR DESCRIPTION
Fix docker compose configuration: using declared docker volume instead of local directory (incorrectlly configued?) for timescale db.

Description:

Was testing lotus locally and wanted to reset the installation. After deleting docker volumes, I found timescale data exist in local directory `./pgdata_xxx` but not declared docker volume, which is misleading.

NOTE: 

May lose data for previous setup created by docker compose.