### PR TITLE
Fixes #786: error creating new customer when address provided 

### DIFF
--- a/backend/api/serializers/model_serializers.py
+++ b/backend/api/serializers/model_serializers.py
@@ -888,17 +888,17 @@ class CustomerCreateSerializer(
         shipping_address = validated_data.pop("shipping_address", None)
         customer = Customer.objects.create(**validated_data)
         if address:
-            address = Address.objects.get_or_create(
+            address, _ = Address.objects.get_or_create(
                 **address, organization=self.context["organization"]
             )
             customer.billing_address = address
         if billing_address:
-            billing_address = Address.objects.get_or_create(
+            billing_address, _ = Address.objects.get_or_create(
                 **billing_address, organization=self.context["organization"]
             )
             customer.billing_address = billing_address
         if shipping_address:
-            shipping_address = Address.objects.get_or_create(
+            shipping_address, _ = Address.objects.get_or_create(
                 **shipping_address, organization=self.context["organization"]
             )
             customer.shipping_address = shipping_address

--- a/backend/metering_billing/views/crm_views.py
+++ b/backend/metering_billing/views/crm_views.py
@@ -362,7 +362,7 @@ def sync_customers_with_salesforce(organization):
                     fuzzy_country = None
 
                 try:
-                    billing_address = Address.objects.get_or_create(
+                    billing_address, _ = Address.objects.get_or_create(
                         line1=billing_address["street"],
                         city=billing_address["city"],
                         state=billing_address["state"],
@@ -372,7 +372,7 @@ def sync_customers_with_salesforce(organization):
                 except Exception:
                     try:
                         normalized = normalize_address_record(billing_address["street"])
-                        billing_address = Address.objects.get_or_create(
+                        billing_address, _ = Address.objects.get_or_create(
                             line1=normalized["address_line_1"],
                             line2=normalized["address_line_2"],
                             city=normalized["city"],
@@ -391,7 +391,7 @@ def sync_customers_with_salesforce(organization):
                     fuzzy_country = None
 
                 try:
-                    shipping_address = Address.objects.get_or_create(
+                    shipping_address, _ = Address.objects.get_or_create(
                         line1=shipping_address["street"],
                         city=shipping_address["city"],
                         state=shipping_address["state"],
@@ -403,7 +403,7 @@ def sync_customers_with_salesforce(organization):
                         normalized = normalize_address_record(
                             shipping_address["street"]
                         )
-                        shipping_address = Address.objects.get_or_create(
+                        shipping_address, _ = Address.objects.get_or_create(
                             line1=normalized["address_line_1"],
                             line2=normalized["address_line_2"],
                             city=normalized["city"],


### PR DESCRIPTION
When creating new customer with address specified, server raises an exception saying:

```
ValueError: Cannot assign "(<Address: Address: 10 Rue de la Paix, Paris, Île-de-France, 75002, FR>, False)": "Customer.billing_address" must be a "Address" instance
```

(Described in issue #786)

The exception occurs when fetching/creating address record, `get_or_create()` method returns a tuple and its first element is the model object we expected. 