### PR TITLE
Security: SQL injection risk via unescaped dynamic identifiers and values in custom aggregation query template

### DIFF
--- a/backend/metering_billing/aggregation/custom_query_templates.py
+++ b/backend/metering_billing/aggregation/custom_query_templates.py
@@ -12,10 +12,10 @@ WITH events AS
         "metering_billing_usageevent"."organization_id" = {{ organization_id }}
         AND "metering_billing_usageevent"."uuidv5_customer_id" = '{{ uuidv5_customer_id }}'
         {%- for property_name, property_values in filter_properties.items() %}
-            AND {{ property_name }}
+            AND "metering_billing_usageevent"."properties"->>'{{ property_name | replace("'", "''") }}'
                 IN (
                     {%- for pval in property_values %}
-                    '{{ pval }}'
+                    '{{ pval | replace("'", "''") }}'
                     {%- if not loop.last %},{% endif %}
                     {%- endfor %}
                 )


### PR DESCRIPTION
## Problem

The SQL template interpolates `property_name` directly into the WHERE clause and injects each `pval` as a quoted string without parameterization. If either field is derived from user-controlled input (directly or indirectly), attackers can alter query structure and execute arbitrary SQL conditions.

**Severity**: `high`
**File**: `backend/metering_billing/aggregation/custom_query_templates.py`

## Solution

Do not interpolate identifiers/values directly into SQL strings. Strictly allowlist column names for `property_name`, and pass all values as query parameters through the DB driver/ORM. If templating is required, use safe identifier quoting utilities and validated enums only.

## Changes

- `backend/metering_billing/aggregation/custom_query_templates.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
