### PR TITLE
Fix cross-org IDOR in SubscriptionViewSet.get_object()

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -772,7 +772,7 @@ class SubscriptionViewSet(
                 "Unexpected state. Could not find subscription_id in request."
             )
         try:
-            obj = self.queryset.get(subscription_record_id=subscription_uuid)
+            obj = self.get_queryset().get(subscription_record_id=subscription_uuid)
         except SubscriptionRecord.DoesNotExist:
             raise NotFoundException(
                 f"Subscription with subscription_id {subscription_id} not found"


### PR DESCRIPTION
## Summary
- Replaces unscoped `self.queryset` with `self.get_queryset()` in `SubscriptionViewSet.get_object()` to enforce organization-level access control
- Prevents authenticated users from accessing subscriptions belonging to other organizations
- Fixes the 1-of-17 inconsistency: the other 16 ViewSets already use `get_queryset()` correctly

## Test plan
- [ ] Verify a user from Org A cannot access a subscription owned by Org B
- [ ] Verify normal subscription operations still work for the owning org

Fixes #799

?? Generated with [Claude Code](https://claude.com/claude-code)